### PR TITLE
Add Oracle AI familiarity to resume skills

### DIFF
--- a/resume.qmd
+++ b/resume.qmd
@@ -26,7 +26,7 @@ format:
 
 ## Skills
 
-Program and project management; decisions from data; experimental & study design; GenAI (e.g., agentic, dual-prompting, multi-step reasoning, contextual understanding, intent recognition); GenAI tools (Agent Development Kit - ADK, API, Google Vertex, ChatGPT, Claude); statistical analysis & ML (e.g., hypothesis testing, causal inference, regression/time-series/hierarchical clustering); ETL; hyperparameter tuning; program R; high-dimensional data collection, cleaning, analysis, visualization, and interpretation; spatial analysis; cloud computing (Snowflake, Azure) & high performance computing (HPC); bash; commitment to diversity, equity, and inclusivity; communication; collaboration; public speaking; teaching; mentorship; writing; budget management
+Program and project management; decisions from data; experimental & study design; GenAI (e.g., agentic, dual-prompting, multi-step reasoning, contextual understanding, intent recognition); GenAI tools (Agent Development Kit - ADK, API, Google Vertex, Oracle AI, ChatGPT, Claude); statistical analysis & ML (e.g., hypothesis testing, causal inference, regression/time-series/hierarchical clustering); ETL; hyperparameter tuning; program R; high-dimensional data collection, cleaning, analysis, visualization, and interpretation; spatial analysis; cloud computing (Snowflake, Azure) & high performance computing (HPC); bash; commitment to diversity, equity, and inclusivity; communication; collaboration; public speaking; teaching; mentorship; writing; budget management
 
 ## Experience Highlights
 


### PR DESCRIPTION
## Summary
- mention familiarity with Oracle AI alongside other GenAI tools in the resume skills section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d45fb4b48c832e87fc125ca4fa91b2