### PR TITLE
Add Policy & Government Engagement section to resume

### DIFF
--- a/resume.qmd
+++ b/resume.qmd
@@ -59,6 +59,12 @@ Program and project management; decisions from data; experimental & study design
 | **Segue Music, West Hollywood, CA** | Computer Consultant; Audio Engineer | 1998–2001 |
 
 
+## Policy & Government Engagement
+
+-   Stanford Woods Institute Rising Environmental Leaders Fellow (competitive, cross-institutional selection); D.C. Policy Leadership Fellow engaging directly with federal officials, White House science analysts, and congressional staff on science-policy translation and environmental legislation. 2012.
+-   As Chief Science Officer at Method Qualitative, directing GenAI and NLP strategy: agentic pipelines, multi-step reasoning, and reflexive prompting for qualitative research at scale.
+-   Led multi-agency science-to-policy translation for the Lake Tahoe West Restoration Partnership, integrating 100-year forest, wildlife, fire, and economic projections with federal, state, tribal, and local stakeholders to produce a formally adopted Landscape Restoration Strategy governing 59,000 acres of federal land.
+
 ## AI Open-Source Code, and Outreach
 
 Abelson, E.S. & Overholt, K. (2025, May 8). *Finding Earth Engine Data Doesn’t Have to Be a Struggle: Let AI Agents Do the Heavy Lifting.* Medium – Google Cloud Community.\
@@ -248,6 +254,7 @@ Stanford Report: Jasper Ridge, Research in the Field at Stanford’s Biological 
 -   UCLA La Kretz Center for California Conservation Science, Post-doctoral Fellowship. 2014-2015
 -   Southern California Research Learning Center’s Grant Program, 2014-2016
 -   National Science Foundation Dissertation Improvement Grant, 2011-2013
+-   Stanford Woods Institute Rising Environmental Leaders D.C. Policy Fellowship (competitive, cross-institutional selection). 2012.
 -   Woods Institute for the Environment, Stanford University, Rising Environmental Leader 2012
 -   Stanford Ecology & Evolutionary Biology Travel Grant, 2012
 -   #SciFund Challenge, 2011


### PR DESCRIPTION
## Summary
Added a new "Policy & Government Engagement" section to the resume highlighting key policy-related roles and accomplishments, and consolidated related fellowship information in the awards section.

## Key Changes
- **New section**: Created "Policy & Government Engagement" section that showcases:
  - Stanford Woods Institute Rising Environmental Leaders Fellowship and D.C. Policy Leadership role (2012)
  - Chief Science Officer position at Method Qualitative with focus on GenAI and NLP strategy
  - Lake Tahoe West Restoration Partnership science-to-policy translation work affecting 59,000 acres of federal land

- **Awards section update**: Added the Stanford Woods Institute Rising Environmental Leaders D.C. Policy Fellowship to the awards/honors list for consistency and completeness

## Implementation Details
The new section is positioned between the "Experience" section and "AI Open-Source Code, and Outreach" section, providing better narrative flow by grouping policy and government engagement work together. The fellowship is now referenced in both the new dedicated section and the awards list to maintain comprehensive documentation of achievements.
